### PR TITLE
Fixes relative path from Terraform source to build artefacts in pipeline

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -154,9 +154,9 @@ jobs:
       env_name: test
       terraform_source: src/terraform/
       vars:
-        adapter_zip_path: ../adapter-zip/adapter.zip
-        broker_zip_path: ../broker-zip/broker.zip
-        stub_zip_path: ../stub-zip/stub.zip
+        adapter_zip_path: ../../adapter-zip/adapter.zip
+        broker_zip_path: ../../broker-zip/broker.zip
+        stub_zip_path: ../../stub-zip/stub.zip
   - task: end-to-end-test
     file: src/ci/test.yml
     vars:
@@ -185,9 +185,9 @@ jobs:
       env_name: test
       terraform_source: src/terraform/
       vars:
-        adapter_zip_path: ../adapter-zip/adapter.zip
-        broker_zip_path: ../broker-zip/broker.zip
-        stub_zip_path: ../stub-zip/stub.zip
+        adapter_zip_path: ../../adapter-zip/adapter.zip
+        broker_zip_path: ../../broker-zip/broker.zip
+        stub_zip_path: ../../stub-zip/stub.zip
   - task: end-to-end-test
     file: src/ci/test.yml
     vars:


### PR DESCRIPTION
What
--- 
Corrects the relative path from the Terraform source files to the build artefacts. Previous path was `../adapter-zip/adapter.zip`. New path is `../../adapter-zip/adapter.zip`. Directory structure is below.

```
tree
.
├── adapter-zip
│   └── adapter.zip
└── src
    └── terraform
        └── main.tf
```

Based on this original message

```
Error: Error in function call

  on adapter.tf line 48, in resource "aws_lambda_function" "adapter":
  48:   source_code_hash = filebase64sha256(var.adapter_zip_path)
    |----------------
    | var.adapter_zip_path is "../adapter-zip/adapter.zip"

Call to function "filebase64sha256" failed: no file exists at
../adapter-zip/adapter.zip.
```

How to review
--- 
Check the relative path makes sense

Who can review
---
Anyone