### PR TITLE
Pass parameters to the end-to-end test task file

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -161,6 +161,8 @@ jobs:
     file: src/ci/test.yml
     vars:
       stub-url: https://test-csls-stub.cloudapps.digital
+      csls_concourse_smoketest_splunk_creds_username: ((csls_concourse_smoketest_splunk_creds_username))
+      csls_concourse_smoketest_splunk_creds_password: ((csls_concourse_smoketest_splunk_creds_password))
 
 - name: deploy
   serial: true


### PR DESCRIPTION
What
---
Passes parameters to the end-to-end test task file

Without passing them through, Concourse fails to interpolate the task config
correctly.

> failed to interpolate task config: undefined vars: csls_concourse_smoketest_splunk_creds_password, csls_concourse_smoketest_splunk_creds_username

How to review
---
Code review, and see [this successful run of the job](https://cd.gds-reliability.engineering/teams/cybersecurity-tools/pipelines/csls-splunk-broker/jobs/test/builds/19.2)

Who can review
---
Anyone