### PR TITLE
Compress data before sending to Kinesis

### DIFF
--- a/pkg/csls/stream.go
+++ b/pkg/csls/stream.go
@@ -70,15 +70,15 @@ func (w *Stream) PutCloudfoundryLog(log cloudfoundry.Log, groupName string) erro
 		},
 	}
 
-	var b bytes.Buffer
-	if err := serialzieForKinesis(&data, &b); err != nil {
+	var json bytes.Buffer
+	if err := serialzieForKinesis(&data, &json); err != nil {
 		return fmt.Errorf("failed-to-serialize-for-kinesis: %s", err)
 	}
 
 	// Kinesis client transparently base64 encodes `Data`
 	_, err := w.AWS.PutRecord(&kinesis.PutRecordInput{
 		StreamName:   aws.String(w.Name),
-		Data:         b.Bytes(),
+		Data:         json.Bytes(),
 		PartitionKey: aws.String(log.Hostname),
 	})
 	if err != nil {

--- a/pkg/csls/stream_test.go
+++ b/pkg/csls/stream_test.go
@@ -1,7 +1,11 @@
 package csls_test
 
 import (
+	"bytes"
+	"compress/gzip"
 	"encoding/json"
+	"fmt"
+	"io/ioutil"
 	"time"
 
 	"github.com/alphagov/paas-csls-splunk-broker/pkg/aws/awsfakes"
@@ -11,6 +15,17 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
+
+func gzipDecompress(b []byte) ([]byte, error) {
+	gz, _ := gzip.NewReader(bytes.NewReader(b))
+	result, err := ioutil.ReadAll(gz)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to decompress data")
+	}
+
+	return result, nil
+}
 
 var _ = Describe("Stream", func() {
 
@@ -37,7 +52,9 @@ var _ = Describe("Stream", func() {
 		}
 		Expect(stream.PutCloudfoundryLog(input, logGroupName)).To(Succeed())
 		Expect(client.PutRecordCallCount()).To(Equal(1))
-		Expect(json.Unmarshal(client.PutRecordArgsForCall(0).Data, &output)).To(Succeed())
+		decompressed, err := gzipDecompress(client.PutRecordArgsForCall(0).Data)
+		Expect(err).To(BeNil())
+		Expect(json.Unmarshal(decompressed, &output)).To(Succeed())
 	})
 
 	It("should set the correct stream name", func() {


### PR DESCRIPTION
This changes makes the broker emulate CloudWatch Logs better. The `kinesis.PutRecordInput.Data` field's content is now gzipped before ingestion.

https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/SubscriptionFilters.html
> The Data attribute in a Kinesis record is Base64 encoded and compressed with the gzip format.

In CSLS there is logic to detect the zip / unzipped logs. I would like to remove it to simplify the parsing code. Having a mix of gzipped and plaintext records makes data analysis during a CSLS failure harder.