### PR TITLE
Try to remove some environment variables to reduce size of config

### DIFF
--- a/ci/codepipeline.tf
+++ b/ci/codepipeline.tf
@@ -122,18 +122,6 @@ resource "aws_codepipeline" "paas-csls-splunk-broker" {
               "name" : "TF_VAR_cf_space",
               "value" : "cyber-sec-sandbox"
             },
-            {
-              "name" : "TF_VAR_adapter_zip_path",
-              "value" : "adapter.zip"
-            },
-            {
-              "name" : "TF_VAR_broker_zip_path",
-              "value" : "broker.zip"
-            },
-            {
-              "name" : "TF_VAR_stub_zip_path",
-              "value" : "stub.zip"
-            },
           ]
         )
       }
@@ -214,18 +202,6 @@ resource "aws_codepipeline" "paas-csls-splunk-broker" {
             {
               "name" : "TF_VAR_cf_space",
               "value" : "cyber-sec-sandbox"
-            },
-            {
-              "name" : "TF_VAR_adapter_zip_path",
-              "value" : "adapter.zip"
-            },
-            {
-              "name" : "TF_VAR_broker_zip_path",
-              "value" : "broker.zip"
-            },
-            {
-              "name" : "TF_VAR_stub_zip_path",
-              "value" : "stub.zip"
             },
           ]
         )

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -61,14 +61,17 @@ variable "csls_broker_password" {
 variable "adapter_zip_path" {
   type        = string
   description = "path to a zip of the compiled adapter application"
+  default     = "adapter.zip"
 }
 
 variable "broker_zip_path" {
   type        = string
   description = "path to a zip of the compiled broker application"
+  default     = "broker.zip"
 }
 
 variable "stub_zip_path" {
   type        = string
   description = "path to a zip of the compiled stub application"
+  default     = "stub.zip"
 }


### PR DESCRIPTION
When trying to update the CodePipeline resource, I got this error:
```
Error: [ERROR] Error updating CodePipeline (paas-csls-splunk-broker): ValidationException: ActionConfiguration Map value must satisfy constraint: [Member must have length less than or equal to 1000, Member must have length greater than or equal to 1]
```

It turns out it was due to the amount of environment variables I had: https://stackoverflow.com/a/71454547/12833309

This PR fixes this issue by removing some Terraform environment variables by using default values instead. Considering both staging and prod used the same 3 zip names, this should have been done earlier in my opinion.